### PR TITLE
[Feat] 팟 상세페이지 조회 API 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "pretendard": "^1.3.9",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
-        "react-router-dom": "^7.13.0"
+        "react-router-dom": "^7.13.0",
+        "react-spinners": "^0.17.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
@@ -61,7 +62,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -377,7 +377,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1591,7 +1590,6 @@
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1633,7 +1631,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1935,7 +1932,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2560,7 +2556,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4224,7 +4219,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4336,7 +4330,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4346,7 +4339,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4406,6 +4398,16 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-spinners": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.17.0.tgz",
+      "integrity": "sha512-L/8HTylaBmIWwQzIjMq+0vyaRXuoAevzWoD35wKpNTxxtYXWZp+xtgkfD7Y4WItuX0YvdxMPU79+7VhhmbmuTQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -5100,7 +5102,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5311,7 +5312,6 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "pretendard": "^1.3.9",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "react-router-dom": "^7.13.0"
+    "react-router-dom": "^7.13.0",
+    "react-spinners": "^0.17.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",

--- a/src/api/PodDetailApi.jsx
+++ b/src/api/PodDetailApi.jsx
@@ -1,0 +1,27 @@
+import { api } from '../lib/api';
+
+// 팟 상세 정보 조회
+export async function fetchPodDetail(podId) {
+  const { data } = await api.get(`/api/meetings/${podId}`);
+
+  return data.data;
+}
+
+// 팟 멤버 출석 체크 상태 변경
+export async function updateAttendance(podId, participantId, attended) {
+  const { data } = await api.patch(`/api/meetings/${podId}/attendance`, {
+    participantId: participantId,
+    attended: attended,
+  });
+
+  return data.data;
+}
+
+// 팟 멤버 상태 배지 변경
+export async function updateStatusBadge(podId, status) {
+  const { data } = await api.patch(`/api/meetings/${podId}/status`, {
+    statusBadge: status,
+  });
+
+  return data.data.statusBadge;
+}

--- a/src/components/pod/PodMember.jsx
+++ b/src/components/pod/PodMember.jsx
@@ -2,6 +2,8 @@ import styled from '@emotion/styled';
 import Goal from '../common/tagChip/Goal';
 import Status from '../common/tagChip/Status';
 import { useState } from 'react';
+import usePodPermissions from '../../hooks/usePodPermissions';
+import { updateStatusBadge } from '../../api/PodDetailApi';
 
 const BADGE_TYPES = [
   'hi',
@@ -15,7 +17,7 @@ const BADGE_TYPES = [
   'goodJob',
 ];
 
-const Badges = ({ setStatus }) => {
+const Badges = ({ setReactionEmoji }) => {
   return (
     <BadgeContainer>
       {BADGE_TYPES.map((type) => (
@@ -25,7 +27,7 @@ const Badges = ({ setStatus }) => {
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
-            setStatus(type);
+            setReactionEmoji(type);
           }}
         >
           <Status type={type} />
@@ -35,29 +37,23 @@ const Badges = ({ setStatus }) => {
   );
 };
 
-// [추가] 추가한 속성들 우선 넣어두었습니다.
 export default function PodMember({
-  id,
-  isMe,
-  profileImage,
-  name,
-  goal,
-  podGoal,
-  mainArea,
-  studyMood,
-  studyType,
-  isHost,
+  pod,
+  member,
   hostMention,
   onHostMentionChange,
-  status: initialStatus,
-  showAttendance,
-  attendenceChecked,
+  canCheckAttendance,
+  attendanceChecked,
   onToggleAttendance,
+  canChangeBadge,
+  onBadgeUpdated,
 }) {
   const [isBadgesVisible, setIsBadgesVisible] = useState(false);
-  const [status, setStatus] = useState(initialStatus);
   const [isUpdated, setIsUpdated] = useState(false); // 멘션 수정 상태
   const [originalMention, setOriginalMention] = useState('');
+
+  // 권한
+  const { isHost, canEditMention } = usePodPermissions(member.memberId, pod);
 
   const handleFocus = (e) => {
     setOriginalMention(e.target.value);
@@ -70,8 +66,16 @@ export default function PodMember({
     e.target.blur();
   };
 
-  const handleStatus = (nextStatus) => {
-    setStatus(nextStatus);
+  const handleReactionEmoji = (status) => {
+    async function updateBadge() {
+      try {
+        await updateStatusBadge(pod.meetingId, status);
+        onBadgeUpdated(member.memberId, status);
+      } catch (error) {
+        console.error('팟 멤버 상태 배지 변경 실패:', error);
+      }
+    }
+    updateBadge();
     setIsBadgesVisible(false);
   };
 
@@ -92,16 +96,16 @@ export default function PodMember({
         )}
         <img
           className="member-profile-image"
-          src={profileImage || '/images/img-placeholder.png'}
-          alt={`${name} 프로필 사진`}
+          src={member.profileImage || '/images/img-placeholder.png'}
+          alt={`${member.nickname} 프로필 사진`}
         />
       </MemberImageWrapper>
       <MemberInfoContainer>
-        <MemberName>{name}</MemberName>
+        <MemberName>{member.nickname}</MemberName>
         <Goal
           as="input"
           readOnly
-          value={podGoal}
+          value={member.goal}
           completed="true"
           style={{
             fontSize: '16px',
@@ -109,48 +113,48 @@ export default function PodMember({
             cursor: 'default',
           }}
         />
-        {isHost ? (
+        {canEditMention ? (
           <HostMention
             name="hostMention"
             placeholder="팟원들에게 전할 말을 입력해주세요!"
             value={hostMention}
-            readOnly={!(isHost && isMe)}
+            readOnly={!canEditMention}
             onChange={onHostMentionChange}
             onFocus={handleFocus}
             onBlur={handleFinishEditing}
             onKeyDown={handleKeyDown}
-            $canEdit={isHost && isMe}
+            $canEdit={canEditMention}
             $isUpdated={isUpdated}
             onClick={(e) => e.stopPropagation()} // [추가] 상세페이지 이동 막기
           />
         ) : (
           <Placeholder />
         )}
-        {showAttendance && (
+        {canCheckAttendance && (
           <AttendanceLabel
             onClick={(e) => e.stopPropagation()} // [추가] 상세페이지 이동 막기
           >
             <HiddenCheckbox
               type="checkbox"
-              aria-label={`${id} 출석 체크`}
-              checked={attendenceChecked}
+              aria-label={`${member.memberId} 출석 체크`}
+              checked={attendanceChecked}
               onChange={onToggleAttendance}
             />
-            <CustomCheckbox $checked={attendenceChecked} aria-hidden />
+            <CustomCheckbox $checked={attendanceChecked} aria-hidden />
           </AttendanceLabel>
         )}
         <StatusBadgeWrapper
           onClick={(e) => {
             e.stopPropagation(); // [추가] 상세페이지 이동 막기
-            setIsBadgesVisible(!isBadgesVisible);
+            canChangeBadge && setIsBadgesVisible(!isBadgesVisible);
           }}
-          style={{ cursor: isMe ? 'pointer' : 'default' }}
+          style={{ cursor: canChangeBadge ? 'pointer' : 'default' }}
         >
           <Status
-            type={status}
-            style={{ cursor: isMe ? 'pointer' : 'default' }}
+            type={member.reactionEmoji}
+            style={{ cursor: canChangeBadge ? 'pointer' : 'default' }}
           />
-          {isMe && isBadgesVisible && (
+          {isBadgesVisible && (
             <>
               <Overlay
                 onClick={(e) => {
@@ -158,7 +162,7 @@ export default function PodMember({
                   setIsBadgesVisible(false);
                 }}
               />
-              <Badges setStatus={handleStatus} />
+              <Badges setReactionEmoji={handleReactionEmoji} />
             </>
           )}
         </StatusBadgeWrapper>

--- a/src/components/pod/PodPreview.jsx
+++ b/src/components/pod/PodPreview.jsx
@@ -2,46 +2,34 @@ import styled from '@emotion/styled';
 import StudyMood from '../common/tagChip/StudyMood';
 import StudyType from '../common/tagChip/StudyType';
 import { useState } from 'react';
+import usePodPermissions from '../../hooks/usePodPermissions';
 
-export default function PodPreview({
-  podImage,
-  podName,
-  location,
-  currentPeople,
-  maxPeople,
-  description,
-  studyMood,
-  studyType,
-  time,
-  place,
-  isEditMode,
-  onInputChange,
-  isHost,
-}) {
+export default function PodPreview({ podDetailInfo, onInputChange }) {
+  const { canEditPodInfo } = usePodPermissions(
+    podDetailInfo.meetingId,
+    podDetailInfo,
+  ); // (임시) 내 아이디: 1
+
   const [updatedField, setUpdatedField] = useState({
     time: false,
     place: false,
   });
-  const [originalField, setOriginalField] = useState({
-    time: time,
-    place: place,
-  });
 
   const handleFocus = (e) => {
     const { name, value } = e.target;
-    setOriginalField((prev) => ({
+    onInputChange((prev) => ({
       ...prev,
       [name]: value,
     }));
   };
 
   const checkUpdate = (name, value) => {
-    if (value !== originalField[name]) {
+    if (value !== podDetailInfo[name]) {
       setUpdatedField((prev) => ({
         ...prev,
         [name]: true,
       }));
-      setOriginalField((prev) => ({
+      onInputChange((prev) => ({
         ...prev,
         [name]: value,
       }));
@@ -50,7 +38,7 @@ export default function PodPreview({
 
   const handleBlurOrEnter = (e) => {
     const { name, value } = e.target;
-    if (value !== originalField[name]) {
+    if (value !== podDetailInfo[name]) {
       setUpdatedField((prev) => ({
         ...prev,
         [name]: true,
@@ -72,44 +60,43 @@ export default function PodPreview({
   return (
     <PodPreviewContainer>
       <ImageWrapper>
-        <img src={podImage} alt="팟 이미지" />
+        <img src={podDetailInfo.representativeImage} alt="팟 이미지" />
       </ImageWrapper>
       <div>
-        <PodName>{podName}</PodName>
+        <PodName>{podDetailInfo.title}</PodName>
         <div>
           <PodPreviewInfoContainer>
             <div>
               <img src="/pod/location.svg" alt="위치 아이콘" />
-              <span>{location}</span>
+              <span>{podDetailInfo.area}</span>
             </div>
             <div>
               <img src="/pod/member.svg" alt="인원 아이콘" />
               <span>
-                {currentPeople}/{maxPeople}
+                {podDetailInfo.participants.current}/
+                {podDetailInfo.participants.max}
               </span>
             </div>
           </PodPreviewInfoContainer>
         </div>
-        <PodPreviewText>
-          <span>{description}</span>
-        </PodPreviewText>
+        <PodPreviewText>{podDetailInfo.description}</PodPreviewText>
         <TagContainer>
-          <StudyMood type={studyMood} />
-          <StudyType type={studyType} />
+          <StudyMood type={podDetailInfo.hashtags[0]} />
+          <StudyType type={podDetailInfo.hashtags[1]} />
         </TagContainer>
         <PodDetailInfoContainer>
-          <PodDetailInfoItem $isEditMode={isEditMode} $canEdit={isHost}>
+          <PodDetailInfoItem>
             <IconWrapper>
               <img src="/pod/time.svg" alt="시간 아이콘" />
-              {isHost && updatedField?.time && <StatusDot />}
+              {canEditPodInfo && updatedField?.time && <StatusDot />}
             </IconWrapper>
             <EditContainer>
               <EditInput
                 name="time"
-                value={time}
+                value={podDetailInfo.date}
                 onChange={onInputChange}
                 $isUpdated={updatedField?.time}
-                $canEdit={isHost}
+                $canEdit={canEditPodInfo}
                 onFocus={handleFocus}
                 onBlur={handleBlurOrEnter}
                 onKeyDown={(e) => {
@@ -118,25 +105,25 @@ export default function PodPreview({
                   }
                 }}
               />
-              {isHost && (
+              {canEditPodInfo && (
                 <EditButton onClick={(e) => handleEditClick('time', e)}>
                   수정
                 </EditButton>
               )}
             </EditContainer>
           </PodDetailInfoItem>
-          <PodDetailInfoItem $isEditMode={isEditMode} $canEdit={isHost}>
+          <PodDetailInfoItem>
             <IconWrapper>
               <img src="/pod/place.svg" alt="장소 아이콘" />
-              {isHost && updatedField?.place && <StatusDot />}
+              {canEditPodInfo && updatedField?.place && <StatusDot />}
             </IconWrapper>
             <EditContainer>
               <EditInput
                 name="place"
-                value={place}
+                value={podDetailInfo.locationDetail}
                 onChange={onInputChange}
                 $isUpdated={updatedField?.place}
-                $canEdit={isHost}
+                $canEdit={canEditPodInfo}
                 onFocus={handleFocus}
                 onBlur={handleBlurOrEnter}
                 onKeyDown={(e) => {
@@ -145,7 +132,7 @@ export default function PodPreview({
                   }
                 }}
               />
-              {isHost && (
+              {canEditPodInfo && (
                 <EditButton onClick={(e) => handleEditClick('place', e)}>
                   수정
                 </EditButton>
@@ -259,8 +246,8 @@ const PodDetailInfoItem = styled.div`
 `;
 
 const EditContainer = styled.div`
-  width: 100%;
   display: flex;
+  width: calc(100% - 30px);
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
@@ -270,7 +257,6 @@ const EditContainer = styled.div`
 const EditInput = styled.input`
   flex: 1;
   min-width: 0;
-  width: ${(props) => props.value.length + 2}ch;
   border: none;
   font-family: inherit;
   font-size: 16px;
@@ -280,7 +266,7 @@ const EditInput = styled.input`
   padding: 0;
   color: ${(props) => (props.$isUpdated ? '#D9695C' : '#000')};
 
-  &: focus {
+  &:focus {
     border-bottom: ${(props) =>
       props.$canEdit ? '1px solid #828282' : 'none'};
   }

--- a/src/hooks/usePodPermissions.jsx
+++ b/src/hooks/usePodPermissions.jsx
@@ -1,0 +1,28 @@
+export default function usePodPermissions(myId, pod) {
+  const participants = Array.isArray(pod?.participants?.list)
+    ? pod.participants.list
+    : [];
+
+  const isHost =
+    pod?.userStatus?.isHost === true &&
+    participants.some(
+      (participant) =>
+        participant.memberId === myId && participant.isHost === true,
+    );
+
+  const isParticipant = participants.some(
+    (participant) => participant.memberId === myId,
+  );
+
+  return {
+    isHost,
+    isParticipant,
+
+    // Permissions
+    canEditPodInfo: isHost,
+    canEditMention: isHost,
+    canCheckAttendance: isHost,
+    canClosePod: isHost,
+    canApplyPod: !isHost && !isParticipant,
+  };
+}

--- a/src/pages/PodDetail.jsx
+++ b/src/pages/PodDetail.jsx
@@ -7,36 +7,50 @@ import ApplyPopup from '../components/popup/Apply';
 import { useEffect, useState } from 'react';
 import ApplyConfirmPopup from '../components/popup/ApplyConfirm';
 import PodClosePopup from '../components/popup/PodClose';
+import { fetchPodDetail } from '../api/PodDetailApi';
+import { BounceLoader } from 'react-spinners';
+import { useParams } from 'react-router-dom';
+import usePodPermissions from '../hooks/usePodPermissions';
+import { updateAttendance } from '../api/PodDetailApi';
 
 export default function PodDetail() {
-  const myId = 3; // (임시) 내 아이디
-  const isHost = false; // (임시) 팟장 모드 전환
+  const { podId } = useParams();
+  const myId = 1; // (임시) 내 아이디
 
-  // 팟장이 수정 가능한 팟 정보
-  const [podInfo, setPodInfo] = useState({
-    time: '1/23 23:00',
-    place: '꽃피다 이화다방',
-    hostMention: '',
-  });
-
-  const handleUpdatedPodInfo = (e) => {
-    const { name, value } = e.target;
-    setPodInfo((prev) => ({
-      ...prev,
-      [name]: value,
-    }));
-  };
-
-  // 참여 신청 팝업
-  const [isClosePopupOpen, setIsClosePopupOpen] = useState(false);
-  const [isApplyPopupOpen, setIsApplyPopupOpen] = useState(false);
-  const [timeChecked, setTimeChecked] = useState(false);
-  const [placeChecked, setPlaceChecked] = useState(false);
-  const [isConfirmPopupOpen, setIsConfirmPopupOpen] = useState(false);
+  // ======= 멤버 더미 데이터 (명세 조정) =======
+  const [members, setMembers] = useState([
+    {
+      memberId: 1,
+      nickname: '모다기',
+      isHost: true,
+      profileImage: '/images/img-placeholder.png',
+      goal: 'Thread 클론 코딩',
+      hasGoal: true,
+      reactionEmoji: 'hi',
+    },
+    {
+      memberId: 2,
+      nickname: '감자',
+      isHost: false,
+      profileImage: '/images/img-placeholder.png',
+      goal: '소플의 리액트 7장 공부',
+      hasGoal: true,
+      reactionEmoji: 'niceToMeet',
+    },
+    {
+      memberId: 3,
+      nickname: '자고싶어요',
+      profileImage: '/images/img-placeholder.png',
+      goal: null,
+      hasGoal: false,
+      reactionEmoji: 'cheerUp',
+    },
+  ]);
 
   // [추가] goal(메인 목표), podGoal(팟 목표), mainArea, studyMood/Type
   // 서버에서 받아올 땐 소속 팟 안에 podGoal 위치
-  const [members, setMembers] = useState([
+  // ========= 멤버 프로필 조회용 데이터 임의 분리 =========
+  const [memberDetails, setMemberDetails] = useState([
     {
       id: 1,
       profileImage: '/images/img-placeholder.png',
@@ -74,16 +88,108 @@ export default function PodDetail() {
       status: 'cheerUp',
     },
   ]);
+  // ======================================
 
-  const [attendenceById, setAttendenceById] = useState(() => {
-    return Object.fromEntries(members.map((member) => [member.id, false]));
+  // 팟 상세 정보
+  const [pod, setPod] = useState(null);
+  // 팟장이 수정 가능한 팟 정보
+  const [editablePodInfo, setEditablePodInfo] = useState({
+    date: '',
+    locationDetail: '',
+    hostAnnouncement: '',
   });
 
-  const onToggleAttendance = (memberId) => {
-    setAttendenceById((prev) => ({
+  // Date 포맷팅 함수
+  function formatDateTime(dateTimeStr) {
+    if (!dateTimeStr) return '';
+    const date = new Date(dateTimeStr);
+
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    const hour = String(date.getHours()).padStart(2, '0');
+    const minute = String(date.getMinutes()).padStart(2, '0');
+
+    return `${month}/${day} ${hour}:${minute}`;
+  }
+
+  // 팟 상세 정보 불러오기
+  useEffect(() => {
+    async function getPodDetail() {
+      const podData = await fetchPodDetail(podId);
+      // ========== (임시) 더미 데이터 세팅 ==========
+      const podDataTemp = {
+        ...podData,
+        representativeImage: '/images/img-placeholder.png',
+        participants: {
+          ...podData.participants,
+          current: podData.participants?.current ?? 3,
+          max: podData.participants?.max ?? 5,
+          list: Array.isArray(podData.participants?.list)
+            ? podData.participants.list
+            : members,
+        },
+        userStatus: {
+          ...podData.userStatus,
+          isHost: true, // (임시) 팟장 여부
+        },
+      };
+      // ==============================================
+      setPod(podDataTemp);
+      setEditablePodInfo({
+        date: formatDateTime(podDataTemp.date),
+        locationDetail: podDataTemp.locationDetail,
+        hostAnnouncement: podDataTemp.hostAnnouncement,
+      });
+    }
+    getPodDetail();
+  }, [podId, members]);
+
+  const { canCheckAttendance } = usePodPermissions(myId, pod);
+
+  // 팟 정보 편집
+  const handleUpdatedPodInfo = (e) => {
+    const { name, value } = e.target;
+    setEditablePodInfo((prev) => ({
       ...prev,
-      [memberId]: !prev[memberId],
+      [name]: value,
     }));
+  };
+
+  // 상태 배지 변경
+  const handleBadgeUpdated = (memberId, nextBadge) => {
+    setMembers((prev) =>
+      prev.map((member) =>
+        member.memberId === memberId
+          ? { ...member, reactionEmoji: nextBadge }
+          : member,
+      ),
+    );
+  };
+
+  // 팝업
+  const [isClosePopupOpen, setIsClosePopupOpen] = useState(false);
+  const [isApplyPopupOpen, setIsApplyPopupOpen] = useState(false);
+  const [isConfirmPopupOpen, setIsConfirmPopupOpen] = useState(false);
+
+  // 팝업 내 체크박스
+  const [timeChecked, setTimeChecked] = useState(false);
+  const [placeChecked, setPlaceChecked] = useState(false);
+
+  // 출석 체크 상태
+  const [attendanceById, setAttendanceById] = useState(() => {
+    return Object.fromEntries(
+      members.map((member) => [member.memberId, false]),
+    );
+  });
+  const onToggleAttendance = async (memberId) => {
+    const nextValue = !attendanceById[memberId];
+
+    setAttendanceById((prev) => ({
+      ...prev,
+      [memberId]: nextValue,
+    }));
+
+    await updateAttendance(pod.meetingId, memberId, nextValue);
   };
 
   // 팝업 뜨면 스크롤 제어
@@ -97,7 +203,8 @@ export default function PodDetail() {
 
   // [추가] 어떤 멤버를 클릭했는지 (null -> 리스트, 선택값o -> 상세페이지)
   const [selectedMemberId, setSelectedMemberId] = useState(null);
-  const selectedMember = members.find((m) => m.id === selectedMemberId) ?? null;
+  const selectedMember =
+    memberDetails.find((m) => m.memberId === selectedMemberId) ?? null;
 
   // [추가] podGoal 갱신
   const updateMemberPodGoal = (memberId, nextPodGoal) => {
@@ -106,23 +213,21 @@ export default function PodDetail() {
     );
   };
 
+  // 로딩화면
+  if (!pod) {
+    return (
+      <LoaderContainer>
+        <BounceLoader color="#D9695C" loading={true} size={60} />
+      </LoaderContainer>
+    );
+  }
+
   return (
     <>
       <PodDetailContainer>
         <PodPreviewContainer>
           <PodPreview
-            podImage="/images/img-placeholder.png"
-            podName="모닥모닥코"
-            location="이대"
-            currentPeople={3}
-            maxPeople={5}
-            description="혼자서는 아무것도 못하는 감자예요🥔 같이 코드 쓸 사람?"
-            studyMood="chatty"
-            studyType="cafe"
-            time={podInfo.time}
-            place={podInfo.place}
-            isHost={isHost}
-            hostMention={podInfo.hostMention}
+            podDetailInfo={{ ...pod, ...editablePodInfo }}
             onInputChange={handleUpdatedPodInfo}
           />
           <ButtonWrapper>
@@ -131,10 +236,12 @@ export default function PodDetail() {
               size="slim"
               width="200px"
               onClick={() => {
-                isHost ? setIsClosePopupOpen(true) : setIsApplyPopupOpen(true);
+                pod.userStatus.isHost
+                  ? setIsClosePopupOpen(true)
+                  : setIsApplyPopupOpen(true);
               }}
             >
-              {isHost ? '팟 모집 종료하기' : '참여 신청하기'}
+              {pod.userStatus.isHost ? '팟 모집 종료하기' : '참여 신청하기'}
             </Button>
           </ButtonWrapper>
         </PodPreviewContainer>
@@ -152,32 +259,24 @@ export default function PodDetail() {
             />
           ) : (
             <>
-              {members.map((member) => (
+              {pod.participants.list.map((member) => (
                 <ClickableMemberWrapper
-                  key={member.id}
-                  onClick={() => setSelectedMemberId(member.id)}
+                  key={member.memberId}
+                  onClick={() => setSelectedMemberId(member.memberId)}
                 >
                   <PodMember
-                    key={member.id}
-                    id={member.id}
-                    isMe={member.id === myId}
-                    profileImage={member.profileImage}
-                    name={member.name}
-                    goal={member.goal}
-                    podGoal={member.podGoal}
-                    mainArea={member.mainArea}
-                    studyMood={member.studyMood}
-                    studyType={member.studyType}
-                    isHost={member.isHost}
-                    hostMention={member.isHost ? podInfo.hostMention : ''}
+                    pod={pod}
+                    member={member}
+                    hostMention={member.isHost ? pod.hostMention : ''}
                     onHostMentionChange={handleUpdatedPodInfo}
-                    status={member.status}
-                    showAttendance={isHost}
-                    attendenceChecked={!!attendenceById[member.id]}
+                    canCheckAttendance={canCheckAttendance}
+                    attendanceChecked={!!attendanceById[member.memberId]}
                     onToggleAttendance={(e) => {
                       e.stopPropagation(); // [추가] 출석체크 클릭할 때, 상세 페이지로 x
-                      onToggleAttendance(member.id);
+                      onToggleAttendance(member.memberId);
                     }}
+                    canChangeBadge={myId === member.memberId}
+                    onBadgeUpdated={handleBadgeUpdated}
                   />
                 </ClickableMemberWrapper>
               ))}
@@ -194,7 +293,7 @@ export default function PodDetail() {
             setTimeChecked={setTimeChecked}
             placeChecked={placeChecked}
             setPlaceChecked={setPlaceChecked}
-            podInfo={podInfo}
+            podInfo={{ ...pod, ...editablePodInfo }}
             onConfirm={() => setIsConfirmPopupOpen(true)}
           />
         </>
@@ -256,6 +355,13 @@ const Overlay = styled.div`
   inset: 0;
   background-color: transparent;
   z-index: 999;
+`;
+
+const LoaderContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
 `;
 
 // [추가]


### PR DESCRIPTION
## 📝 작업 내용
> 리뷰어가 코드를 보지 않고도 '무엇을', '왜' 했는지 알 수 있게 요약해 주세요.

- 멘토링 내용 기반으로 `usePodPermissions` 훅을 추가하고, 권한을 정리하였습니다.
- 팟 상세페이지 조회 API를 연동하였습니다.
  - `podId=1` 더미데이터를 기반으로 정보를 조회합니다.
  - `participants`, `userStatus` 더미데이터가 채워지지 않아 임의로 구성한 `members`를 연결하였습니다.
- 상태 업데이트 API를 연동하였습니다.
  - 현재 `myId=1`로 임시 하드코딩 되어 있어 `모다기` 사용자의 상태 배지 변경이 가능합니다.
- 더미데이터 관련 문제는 백엔드에 수정 요청 드린 상태입니다.

## 📸 스크린샷 (선택)
> 구현 화면의 스크린샷(jpg, gif)를 첨부해주세요.
<img width="100%" alt="image" src="https://github.com/user-attachments/assets/141cc183-2bb9-4b09-9fdf-657613006443" />


## 💬 리뷰 요구사항
> 동료가 집중해서 봐줬으면 하는 부분을 콕 집어주세요. 
> 고민했던 부분, 궁금한 점 등에 대해 적어도 좋습니다.

- 현재 더미데이터가 다 채워지지 않아 `member` 관련 정보는 작업하지 않았습니다. 멘토링 기반으로 수정한 권한 설정과 `PodPreview` 내용 위주로 확인해주시면 감사하겠습니다!
- 위와 같은 이유로 이전에 코멘트 주셨던 목표 입력 전 컴포넌트 색상 문제는 다음 작업에서 해결하겠습니다. 


## 👩🏻‍🏫 멘토링 요청사항 (선택)
> 멘토링 전 main 브랜치에 병합하는 PR을 올릴 때 작성해주세요. 
> 작업하면서 어려웠던 부분, 리뷰해주었으면 하는 부분 등 멘토링이 필요한 부분에 대해 자세히 작성해주세요.

- 권한 로직은 컴포넌트 내부에서 구성하는 게 좋은지, 아니면 상위 컴포넌트에서 props로 내려주는 게 좋은지 궁금합니다. 어떤 방식이 유지 보수에 좋은가요?
  - 예를 들어 현재 `canEditMention`은 `PodMember` 내부에서 호출하고, `canCheckAttendance`는 `PodDetail`에서 `PodMember`로 내려주고 있습니다. 기능 작동 여부로 두 위치를 결정했는데 설계 기준이 있을까요?
- `PodDetail`과 `PodMember`의 관계가 잘 설정되어 있는 게 맞는지 궁금합니다...!


## ✅ 셀프 체크리스트
> 아래 체크리스트가 모두 완료되어야 병합할 수 있습니다.

- [x] 브랜치 방향 확인 (current branch (ex. feat/login -> develop))
- [x] 문법 오류 확인 (ESLint)
- [x] 코드 포맷팅 적용 (Prettier)