### PR TITLE
[Feat] 공부 카테고리 Chip 추가 및 PodPreview 수정

### DIFF
--- a/src/components/common/tagChip/StudyCategory.jsx
+++ b/src/components/common/tagChip/StudyCategory.jsx
@@ -1,0 +1,29 @@
+import Pill from './Pill';
+
+const STUDY_CATEGORY_DATA = {
+  EXAMS: { label: '#시험대비', backgroundColor: 'rgba(255, 187, 13, 0.55)' },
+  PROJECTS: {
+    label: '#과제·팀플',
+    backgroundColor: 'rgba(0, 159, 40, 0.55)',
+  },
+  CODING: { label: '#프로그래밍', backgroundColor: 'rgba(255, 72, 0, 0.55)' },
+  LANGUAGES: { label: '#어학', backgroundColor: 'rgba(66, 204, 155, 0.55)' },
+  CERTS: { label: '#자격증', backgroundColor: 'rgba(255, 9, 13, 0.55)' },
+  JOBS: { label: '#취업준비', backgroundColor: 'rgba(34, 67, 251, 0.55)' },
+  READING: { label: '#독서', backgroundColor: 'rgba(255, 114, 231, 0.55)' },
+  GROWTH: { label: '#자기계발', backgroundColor: 'rgba(165, 165, 165, 0.55)' },
+};
+
+export default function StudyCategory({ type, size = 'small' }) {
+  const studyCategory = STUDY_CATEGORY_DATA[type] || {};
+  return (
+    <Pill
+      variant="filled"
+      size={size}
+      backgroundColor={studyCategory.backgroundColor}
+      style={{ cursor: 'default' }}
+    >
+      {studyCategory.label}
+    </Pill>
+  );
+}

--- a/src/components/pod/PodPreview.jsx
+++ b/src/components/pod/PodPreview.jsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import StudyMood from '../common/tagChip/StudyMood';
 import StudyType from '../common/tagChip/StudyType';
 import { useState } from 'react';
+import StudyCategory from '../common/tagChip/StudyCategory';
 
 export default function PodPreview({
   podDetailInfo,
@@ -67,6 +68,7 @@ export default function PodPreview({
         <TagContainer>
           <StudyMood type={podDetailInfo.hashtags[0]} />
           <StudyType type={podDetailInfo.hashtags[1]} />
+          <StudyCategory type="CODING" />
         </TagContainer>
         <PodDetailInfoContainer>
           <PodDetailInfoItem>

--- a/src/components/pod/PodPreview.jsx
+++ b/src/components/pod/PodPreview.jsx
@@ -68,7 +68,7 @@ export default function PodPreview({
         <TagContainer>
           <StudyMood type={podDetailInfo.hashtags[0]} />
           <StudyType type={podDetailInfo.hashtags[1]} />
-          <StudyCategory type="CODING" />
+          <StudyCategory type="CODING" /> {/* 추후 데이터 연동 */}
         </TagContainer>
         <PodDetailInfoContainer>
           <PodDetailInfoItem>
@@ -206,6 +206,7 @@ const TagContainer = styled.div`
   align-items: center;
   gap: 6px;
   margin-bottom: 25px;
+  flex-wrap: wrap;
 `;
 
 const PodDetailInfoContainer = styled.div`


### PR DESCRIPTION
## 📝 작업 내용
> 리뷰어가 코드를 보지 않고도 '무엇을', '왜' 했는지 알 수 있게 요약해 주세요.

- 공부 카테고리 (eg. 시험 대비, 프로그래밍 등) Chip 컴포넌트를 구현했습니다.
- PodPreview 컴포넌트에 공부 카테고리 Chip을 추가했습니다.


## 📸 스크린샷 (선택)
> 구현 화면의 스크린샷(jpg, gif)를 첨부해주세요.
- 아직 백엔드 명세 수정 전이므로 "CODING"으로 하드코딩 하였습니다. (추후 수정)
<img width="100%" alt="image" src="https://github.com/user-attachments/assets/0cfe97d8-62e5-4dde-a1e6-f4e2e489638d" />



## 💬 리뷰 요구사항
> 동료가 집중해서 봐줬으면 하는 부분을 콕 집어주세요. 
> 고민했던 부분, 궁금한 점 등에 대해 적어도 좋습니다.

- 팟 상세페이지에서 "프로그래밍" Chip이 출력되는 것을 확인해주세요!



## ✅ 셀프 체크리스트
> 아래 체크리스트가 모두 완료되어야 병합할 수 있습니다.

- [x] 브랜치 방향 확인 (current branch (ex. feat/login -> develop))
- [x] 문법 오류 확인 (ESLint)
- [x] 코드 포맷팅 적용 (Prettier)