### PR TITLE
[Fix] 인증 페이지 반응형 스타일 및 UX 개선

### DIFF
--- a/src/components/common/Button.jsx
+++ b/src/components/common/Button.jsx
@@ -15,17 +15,17 @@ const StyledButton = styled.button`
     const styleDefaults = {
       chip: {
         // 회고 마무리 버튼
-        large: { h: '50px', fz: '24px', fw: '600', p: '10px 20px' },
+        large: { h: '50px', fz: '20px', fw: '600', p: '10px 20px' },
         // 팝업 버튼
-        medium: { h: '50px', fz: '20px', fw: '400', p: '13px 23px' },
+        medium: { h: '50px', fz: '16px', fw: '400', p: '13px 23px' },
         // 홈 화면 확인하기 버튼
-        small: { h: '39px', fz: '20px', fw: '400', p: '0 0' },
+        small: { h: '39px', fz: '16px', fw: '400', p: '0 0' },
       },
       rect: {
-        large: { h: '61px', fz: '20px', fw: '500', p: '0 20px' },
+        large: { h: '61px', fz: '16px', fw: '500', p: '0 20px' },
         // 참여 신청하기 버튼
-        slim: { h: '40px', fz: '14px', fw: '500', p: '0 20px' },
-        full: { h: '61px', fz: '20px', fw: '500', p: '0 20px' },
+        slim: { h: '40px', fz: '10px', fw: '500', p: '0 20px' },
+        full: { h: '61px', fz: '16px', fw: '500', p: '0 20px' },
       },
     };
 

--- a/src/components/common/Button.jsx
+++ b/src/components/common/Button.jsx
@@ -15,17 +15,17 @@ const StyledButton = styled.button`
     const styleDefaults = {
       chip: {
         // 회고 마무리 버튼
-        large: { h: '50px', fz: '20px', fw: '600', p: '10px 20px' },
+        large: { h: '50px', fz: '24px', fw: '600', p: '10px 20px' },
         // 팝업 버튼
-        medium: { h: '50px', fz: '16px', fw: '400', p: '13px 23px' },
+        medium: { h: '50px', fz: '20px', fw: '400', p: '13px 23px' },
         // 홈 화면 확인하기 버튼
-        small: { h: '39px', fz: '16px', fw: '400', p: '0 0' },
+        small: { h: '39px', fz: '20px', fw: '400', p: '0 0' },
       },
       rect: {
-        large: { h: '61px', fz: '16px', fw: '500', p: '0 20px' },
+        large: { h: '61px', fz: '20px', fw: '500', p: '0 20px' },
         // 참여 신청하기 버튼
-        slim: { h: '40px', fz: '10px', fw: '500', p: '0 20px' },
-        full: { h: '61px', fz: '16px', fw: '500', p: '0 20px' },
+        slim: { h: '40px', fz: '14px', fw: '500', p: '0 20px' },
+        full: { h: '61px', fz: '20px', fw: '500', p: '0 20px' },
       },
     };
 

--- a/src/components/common/Input.jsx
+++ b/src/components/common/Input.jsx
@@ -48,6 +48,18 @@ const StyledInput = styled.input`
   color: #000;
   background-color: #fff;
 
+  &::-ms-reveal,
+  &::-ms-clear {
+    display: none;
+  }
+
+  &::-webkit-contacts-auto-fill-button,
+  &::-webkit-credentials-auto-fill-button {
+    visibility: hidden;
+    display: none !important;
+    pointer-events: none;
+  }
+
   &::placeholder {
     color: ${(props) => (props.variant === 'black' ? '#D9D9D9' : '#A5A5A5')};
     font-weight: 400;

--- a/src/components/common/Input.jsx
+++ b/src/components/common/Input.jsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { useState } from 'react';
 
 const InputWrapper = styled.div`
   display: flex;
@@ -19,12 +20,23 @@ const Label = styled.label`
   margin-bottom: ${(props) => props.labelGap || '0'};
 `;
 
+const InputRow = styled.div`
+  width: 100%;
+  position: relative;
+  display: flex;
+  align-items: center;
+`;
+
 const StyledInput = styled.input`
   width: 100%;
   /* 팟 만들기(50px), 회원가입(61px), 기타(40px) */
   height: ${(props) => props.height || '61px'};
   /* 회원가입(13/20), 팟 만들기(14/23), 기타(11/19) */
   padding: ${(props) => props.padding || '13px 20px'};
+  padding-right: ${(props) =>
+    props.hasClearBtn || props.hasToggleBtn
+      ? '48px'
+      : props.padding?.split(' ')[1] || '20px'};
 
   border: 1px solid ${(props) => (props.hasHelperText ? '#D9695C' : '#000')};
   border-radius: 10px;
@@ -44,6 +56,31 @@ const StyledInput = styled.input`
   &:focus {
     border: 1px solid ${(props) => (props.hasHelperText ? '#D9695C' : '#000')};
   }
+`;
+
+const IconButton = styled.button`
+  position: absolute;
+  right: 14px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #535353;
+
+  &:hover {
+    color: #000;
+  }
+`;
+
+const ClearButton = styled(IconButton)`
+  right: 14px;
+`;
+
+const ToggleButton = styled(IconButton)`
+  right: ${(props) => (props.hasClearBtn ? '45px' : '14px')};
 `;
 
 const HelperText = styled.div`
@@ -67,8 +104,24 @@ export default function Input({
   fontSize,
   fontWeight,
   variant,
+  clearable,
+  showPasswordToggle,
+  onChange,
   ...props
 }) {
+  const [showPassword, setShowPassword] = useState(false);
+  const handleClear = () => {
+    onChange?.({ target: { name: props.name, value: '' } });
+  };
+
+  const inputType = showPasswordToggle
+    ? showPassword
+      ? 'text'
+      : 'password'
+    : props.type;
+
+  const hasValue = !!props.value;
+
   return (
     <InputWrapper width={width}>
       {label && (
@@ -77,15 +130,88 @@ export default function Input({
         </Label>
       )}
 
-      <StyledInput
-        height={height}
-        padding={padding}
-        fontSize={fontSize}
-        fontWeight={fontWeight}
-        variant={variant}
-        hasHelperText={!!helperText}
-        {...props}
-      />
+      <InputRow>
+        <StyledInput
+          {...props}
+          type={inputType}
+          height={height}
+          padding={padding}
+          fontSize={fontSize}
+          fontWeight={fontWeight}
+          variant={variant}
+          hasHelperText={!!helperText}
+          hasClearBtn={clearable}
+          hasToggleBtn={showPasswordToggle}
+          onChange={onChange}
+        />
+
+        {clearable && hasValue && (
+          <ClearButton type="button" onClick={handleClear} tabIndex={-1}>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+            >
+              <path
+                d="M18 6L6 18"
+                stroke="#535353"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M6 6L18 18"
+                stroke="#535353"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+          </ClearButton>
+        )}
+
+        {showPasswordToggle && (
+          <ToggleButton
+            type="button"
+            onClick={() => setShowPassword((v) => !v)}
+            tabIndex={-1}
+            hasClearBtn={clearable && hasValue}
+          >
+            {showPassword ? (
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M17.94 17.94A10.07 10.07 0 0112 20c-7 0-11-8-11-8a18.45 18.45 0 015.06-5.94" />
+                <path d="M9.9 4.24A9.12 9.12 0 0112 4c7 0 11 8 11 8a18.5 18.5 0 01-2.16 3.19" />
+                <line x1="1" y1="1" x2="23" y2="23" />
+              </svg>
+            ) : (
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                <circle cx="12" cy="12" r="3" />
+              </svg>
+            )}
+          </ToggleButton>
+        )}
+      </InputRow>
 
       {helperText && <HelperText>{helperText}</HelperText>}
     </InputWrapper>

--- a/src/components/common/Input.jsx
+++ b/src/components/common/Input.jsx
@@ -15,7 +15,7 @@ const Label = styled.label`
   align-items: center;
   height: 34px;
   color: #000;
-  font-size: ${(props) => props.fontSize || '16px'};
+  font-size: ${(props) => props.fontSize || '12px'};
   font-weight: ${(props) => props.fontWeight || '400'};
   margin-bottom: ${(props) => props.labelGap || '0'};
 `;
@@ -43,7 +43,7 @@ const StyledInput = styled.input`
   box-sizing: border-box;
   outline: none;
   font-family: inherit;
-  font-size: ${(props) => props.fontSize || '16px'};
+  font-size: ${(props) => props.fontSize || '12px'};
   font-weight: ${(props) => props.fontWeight || '400'};
   color: #000;
   background-color: #fff;
@@ -85,7 +85,7 @@ const ToggleButton = styled(IconButton)`
 
 const HelperText = styled.div`
   font-family: 'Pretendard', sans-serif;
-  font-size: 16px;
+  font-size: 12px;
   font-weight: 400;
   margin-top: 4px;
   height: 27px;

--- a/src/components/common/Input.jsx
+++ b/src/components/common/Input.jsx
@@ -15,7 +15,7 @@ const Label = styled.label`
   align-items: center;
   height: 34px;
   color: #000;
-  font-size: ${(props) => props.fontSize || '12px'};
+  font-size: ${(props) => props.fontSize || '16px'};
   font-weight: ${(props) => props.fontWeight || '400'};
   margin-bottom: ${(props) => props.labelGap || '0'};
 `;
@@ -43,7 +43,7 @@ const StyledInput = styled.input`
   box-sizing: border-box;
   outline: none;
   font-family: inherit;
-  font-size: ${(props) => props.fontSize || '12px'};
+  font-size: ${(props) => props.fontSize || '16px'};
   font-weight: ${(props) => props.fontWeight || '400'};
   color: #000;
   background-color: #fff;
@@ -85,7 +85,7 @@ const ToggleButton = styled(IconButton)`
 
 const HelperText = styled.div`
   font-family: 'Pretendard', sans-serif;
-  font-size: 12px;
+  font-size: 16px;
   font-weight: 400;
   margin-top: 4px;
   height: 27px;

--- a/src/components/layout/NavBar.jsx
+++ b/src/components/layout/NavBar.jsx
@@ -161,9 +161,9 @@ export default function NavBar() {
 
   const handleLogout = () => {
     localStorage.clear();
-
-    alert('로그아웃 되었습니다.');
     setIsLoggedIn(false);
+    alert('로그아웃 되었습니다.');
+    navigate('/', { replace: true });
   };
 
   return (

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -29,14 +29,9 @@ export default function LoginPage() {
     }
   };
 
-  const handleFindIdLink = (e) => {
+  const handleFindAccountLink = (e) => {
     e.preventDefault();
-    navigate('/find-id');
-  };
-
-  const handleFindPwLink = (e) => {
-    e.preventDefault();
-    navigate('/find-pw');
+    navigate('/find-account');
   };
 
   const handleLogin = async (e) => {
@@ -116,15 +111,11 @@ export default function LoginPage() {
             clearable
           />
         </InputWrapper>
-        <FindLinksWrapper>
-          <ForgotLink href="#" onClick={handleFindIdLink}>
-            아이디
+        <FindLinkWrapper>
+          <ForgotLink href="#" onClick={handleFindAccountLink}>
+            아이디 / 비밀번호 찾기
           </ForgotLink>
-          <SeparatorText>/</SeparatorText>
-          <ForgotLink href="#" onClick={handleFindPwLink}>
-            비밀번호 찾기
-          </ForgotLink>
-        </FindLinksWrapper>
+        </FindLinkWrapper>
 
         <ButtonWrapper>
           <Button
@@ -208,7 +199,7 @@ const InputWrapper = styled.div`
   margin-bottom: 4px;
 `;
 
-const FindLinksWrapper = styled.div`
+const FindLinkWrapper = styled.div`
   display: flex;
   justify-content: flex-end;
   width: 100%;
@@ -216,19 +207,13 @@ const FindLinksWrapper = styled.div`
 `;
 
 const ForgotLink = styled.a`
-  font-size: 16px;
+  font-size: 12px;
   color: #a5a5a5;
   margin-bottom: 40px;
 
   &:hover {
     text-decoration: underline;
   }
-`;
-
-const SeparatorText = styled.span`
-  font-size: 16px;
-  color: #a5a5a5;
-  user-select: none;
 `;
 
 const ButtonWrapper = styled.div`
@@ -268,7 +253,7 @@ const ButtonWrapper = styled.div`
 
 const Separator = styled.div`
   text-align: center;
-  font-size: 16px;
+  font-size: 12px;
   color: #000;
   margin: 0;
   position: relative;

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -150,7 +150,6 @@ export default function LoginPage() {
             onError={() => {
               console.log('Login Failed');
             }}
-            width="380"
             use_fedcm_for_prompt={true}
           />
         </ButtonWrapper>
@@ -177,17 +176,25 @@ const ContentWrapper = styled.div`
   align-items: center;
   width: 100%;
   max-width: 400px;
-  padding: 60px 10px;
+  padding: 60px 20px;
   flex-grow: 1;
   box-sizing: border-box;
+
+  @media (max-width: 480px) {
+    padding: 40px 16px;
+  }
 `;
 
 const LogoImage = styled.img`
-  width: 355px;
+  max-width: 355px;
   height: 106px;
-  aspect-ratio: 355 / 106;
   object-fit: contain;
   margin-bottom: 44px;
+
+  @media (max-width: 400px) {
+    width: 100%;
+    height: auto;
+  }
 `;
 
 const InputWrapper = styled.div`
@@ -235,12 +242,10 @@ const ButtonWrapper = styled.div`
 
   & > div {
     width: 100% !important;
-    display: flex !important;
-    justify-content: center !important;
 
     iframe {
       width: 100% !important;
-      margin: 0 auto !important;
+      margin: unset !important;
     }
   }
 `;

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -102,6 +102,7 @@ export default function LoginPage() {
             label="아이디"
             size="large"
             fullWidth
+            clearable
           />
           <Input
             type="password"
@@ -112,6 +113,7 @@ export default function LoginPage() {
             size="large"
             fullWidth
             showPasswordToggle
+            clearable
           />
         </InputWrapper>
         <FindLinksWrapper>
@@ -191,7 +193,7 @@ const LogoImage = styled.img`
   object-fit: contain;
   margin-bottom: 44px;
 
-  @media (max-width: 400px) {
+  @media (max-width: 480px) {
     width: 100%;
     height: auto;
   }
@@ -238,6 +240,20 @@ const ButtonWrapper = styled.div`
 
   & > button {
     width: 100%;
+  }
+
+  & > button:first-of-type {
+    transition: all 0.2s ease-in-out;
+    &:hover {
+      background-color: #e59990;
+    }
+  }
+
+  & > button:nth-of-type(2) {
+    transition: all 0.2s ease-in-out;
+    &:hover {
+      background-color: #e6e6e6;
+    }
   }
 
   & > div {

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -207,7 +207,7 @@ const FindLinkWrapper = styled.div`
 `;
 
 const ForgotLink = styled.a`
-  font-size: 12px;
+  font-size: 16px;
   color: #a5a5a5;
   margin-bottom: 40px;
 
@@ -253,7 +253,7 @@ const ButtonWrapper = styled.div`
 
 const Separator = styled.div`
   text-align: center;
-  font-size: 12px;
+  font-size: 16px;
   color: #000;
   margin: 0;
   position: relative;

--- a/src/pages/Onboarding.jsx
+++ b/src/pages/Onboarding.jsx
@@ -40,8 +40,11 @@ const OnboardingContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   min-height: 100vh;
   background-color: #fff;
+  padding: 0 20px;
+  box-sizing: border-box;
 `;
 
 const ContentWrapper = styled.div`
@@ -55,10 +58,12 @@ const ContentWrapper = styled.div`
 `;
 
 const LogoWrapper = styled.div`
-  margin-top: 200px;
-  margin-bottom: 70px;
+  margin-top: 28vh;
+  margin-bottom: 10vh;
   display: flex;
   align-items: center;
+  width: 80%;
+  max-width: 300%;
   justify-content: center;
 `;
 
@@ -72,5 +77,23 @@ const ButtonArea = styled.div`
   display: flex;
   flex-direction: column;
   gap: 20px;
-  width: 160px;
+  width: 100%;
+  max-width: 160px;
+  margin-bottom: 5vh;
+
+  & > button:first-of-type {
+    transition: all 0.2s ease-in-out;
+
+    &:hover {
+      background-color: #e59990;
+    }
+  }
+
+  & > button:last-of-type {
+    transition: all 0.2s ease-in-out;
+
+    &:hover {
+      background-color: #e6e6e6;
+    }
+  }
 `;

--- a/src/pages/Onboarding.jsx
+++ b/src/pages/Onboarding.jsx
@@ -55,6 +55,12 @@ const ContentWrapper = styled.div`
   gap: 9px;
   width: 100%;
   max-width: 450px;
+
+  @media (max-width: 480px) {
+    max-width: 100%;
+    padding: 0 20px;
+    box-sizing: border-box;
+  }
 `;
 
 const LogoWrapper = styled.div`
@@ -65,6 +71,10 @@ const LogoWrapper = styled.div`
   width: 80%;
   max-width: 300%;
   justify-content: center;
+
+  @media (max-width: 480px) {
+    width: 100%;
+  }
 `;
 
 const LogoImage = styled.img`

--- a/src/pages/Onboarding.jsx
+++ b/src/pages/Onboarding.jsx
@@ -81,9 +81,17 @@ const ButtonArea = styled.div`
   max-width: 160px;
   margin-bottom: 5vh;
 
+  & > button {
+    padding: 10px 12px;
+    word-break: keepall;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    white-space: nowrap;
+  }
+
   & > button:first-of-type {
     transition: all 0.2s ease-in-out;
-
     &:hover {
       background-color: #e59990;
     }
@@ -91,7 +99,6 @@ const ButtonArea = styled.div`
 
   & > button:last-of-type {
     transition: all 0.2s ease-in-out;
-
     &:hover {
       background-color: #e6e6e6;
     }

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -401,7 +401,7 @@ const RowWrapper = styled.div`
 const SideButton = styled(Button)`
   margin-top: 34px;
   white-space: nowrap;
-  font-size: 12px;
+  font-size: 16px;
 `;
 
 const PinkBox = styled.div`
@@ -418,7 +418,7 @@ const PinkBox = styled.div`
 const SectionLabel = styled.label`
   color: #000;
   font-family: Pretendard;
-  font-size: 12px;
+  font-size: 16px;
   font-weight: 400;
   height: 34px;
   line-height: 34px;
@@ -450,7 +450,7 @@ const SubBox = styled.div`
 `;
 
 const PlusIcon = styled.span`
-  font-size: 16px;
+  font-size: 20px;
   font-weight: 400;
   color: #000;
 `;
@@ -459,7 +459,7 @@ const PillButton = styled(Button)`
   min-width: 0;
   flex: 1;
   height: 27px !important;
-  font-size: 12px !important;
+  font-size: 16px !important;
   font-weight: 600 !important;
   padding: 9px 22px !important;
   box-shadow: none !important;

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -213,6 +213,7 @@ export default function Signup() {
             onChange={handleChange}
             width="80%"
             placeholder="한글 또는 영어를 포함하는 2-10자"
+            clearable
           />
           <SideButton
             type="button"
@@ -233,6 +234,7 @@ export default function Signup() {
             onChange={handleChange}
             width="80%"
             placeholder="영어, 숫자를 포함하는 4-20자"
+            clearable
           />
           <SideButton
             type="button"
@@ -252,6 +254,7 @@ export default function Signup() {
             onChange={handleChange}
             width="80%"
             placeholder="예) example@email.com"
+            clearable
           />
           <SideButton
             type="button"
@@ -271,6 +274,8 @@ export default function Signup() {
           value={formData.password}
           onChange={handleChange}
           placeholder="영어, 숫자, 특수문자를 포함하는 8-20자"
+          showPasswordToggle
+          clearable
         />
         <Input
           type="password"
@@ -279,6 +284,8 @@ export default function Signup() {
           name="passwordConfirm"
           value={formData.passwordConfirm}
           onChange={handleChange}
+          showPasswordToggle
+          clearable
         />
 
         <PinkBox>

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -401,7 +401,7 @@ const RowWrapper = styled.div`
 const SideButton = styled(Button)`
   margin-top: 34px;
   white-space: nowrap;
-  font-size: 16px;
+  font-size: 12px;
 `;
 
 const PinkBox = styled.div`
@@ -418,7 +418,7 @@ const PinkBox = styled.div`
 const SectionLabel = styled.label`
   color: #000;
   font-family: Pretendard;
-  font-size: 16px;
+  font-size: 12px;
   font-weight: 400;
   height: 34px;
   line-height: 34px;
@@ -450,7 +450,7 @@ const SubBox = styled.div`
 `;
 
 const PlusIcon = styled.span`
-  font-size: 20px;
+  font-size: 16px;
   font-weight: 400;
   color: #000;
 `;
@@ -459,7 +459,7 @@ const PillButton = styled(Button)`
   min-width: 0;
   flex: 1;
   height: 27px !important;
-  font-size: 16px !important;
+  font-size: 12px !important;
   font-weight: 600 !important;
   padding: 9px 22px !important;
   box-shadow: none !important;


### PR DESCRIPTION
## 📝 작업 내용
> 리뷰어가 코드를 보지 않고도 '무엇을', '왜' 했는지 알 수 있게 요약해 주세요.

### Onboarding, Login 페이지 반응형 디자인
- 480px 이하 모바일 화면에 미디어 쿼리 적용

### 인터랙션 개선
- 로그인 화면 아이디, 비밀번호 입력창 toggle/clear 버튼 추가 및 겹침 현상 해결
- 로그인/회원가입 버튼 hover 스타일 추가

### UX 개선
- 로그인 화면 아이디/비밀번호 찾기 라우팅 통합(/find-id, /find-pw -> /find-account)
- 로그아웃 버튼 시 온보딩 페이지로 리다이렉트

## 📸 스크린샷 (선택)
> 구현 화면의 스크린샷(jpg, gif)를 첨부해주세요.
- hover 스타일 적용
<img width="1914" height="855" alt="image" src="https://github.com/user-attachments/assets/c940a8aa-4b3a-485b-9976-13cfdf913ef8" />


<img width="1916" height="848" alt="image" src="https://github.com/user-attachments/assets/d1d27333-e5fe-4e66-bafd-762e1c0ae828" />


- 로그인, 회원가입 화면 아이디, 비밀번호 입력창 toggle/clear 버튼 추가
<img width="1895" height="813" alt="image" src="https://github.com/user-attachments/assets/8bc0d3ba-2f09-48f4-a0cc-3bea788efc40" />


<img width="1897" height="842" alt="image" src="https://github.com/user-attachments/assets/52ed0dd4-dbd7-47f3-bc45-21f486e954ff" />


## 💬 리뷰 요구사항
> 동료가 집중해서 봐줬으면 하는 부분을 콕 집어주세요. 
> 고민했던 부분, 궁금한 점 등에 대해 적어도 좋습니다.

- 폰트 사이즈를 줄였는데 너무 작진 않은지 봐주시면 감사하겠습니다! -> (폰트 사이즈 4px씩 원래대로 늘림)

## ✅ 셀프 체크리스트
> 아래 체크리스트가 모두 완료되어야 병합할 수 있습니다.

- [x] 브랜치 방향 확인 (current branch (ex. feat/login -> develop))
- [x] 문법 오류 확인 (ESLint)
- [x] 코드 포맷팅 적용 (Prettier)